### PR TITLE
specify source URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
 	"name": "psalm/phar",
 	"description": "Composer-based Psalm Phar",
 	"license": ["MIT"],
+	"support": {
+		"source": "https://github.com/vimeo/psalm"
+	},
 	"require": {
 		"php": "^7.1 || ^8.0"
 	},


### PR DESCRIPTION
Hi,

Im curious if dependency tools like renovate will consider this directive for showing actual changelogs.

The current changelog is a bit useless :sweat_smile: 

https://github.com/psalm/phar/compare/5.19.1...5.20.0